### PR TITLE
Added Sort property and ItemEnd field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-center",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "The Message Center app is a solution that reads service messages data from a SharePoint list and presents it to all users with an intuitive interface.",
   "main": "src/index.ts",
   "scripts": {

--- a/spfx/config/package-solution.json
+++ b/spfx/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "message-center",
     "id": "22c60fcb-b8cd-4e9e-98bf-f2e15bd4acfc",
-    "version": "0.0.2.10",
+    "version": "0.0.3.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/spfx/config/package-solution.json
+++ b/spfx/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "message-center",
     "id": "22c60fcb-b8cd-4e9e-98bf-f2e15bd4acfc",
-    "version": "0.0.2.1",
+    "version": "0.0.2.10",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/spfx/package.json
+++ b/spfx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-center",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "engines": {
     "node": ">=16.13.0 <17.0.0 || >=18.17.1 <19.0.0"

--- a/spfx/src/webparts/messageCenter/MessageCenterWebPart.manifest.json
+++ b/spfx/src/webparts/messageCenter/MessageCenterWebPart.manifest.json
@@ -38,7 +38,8 @@
         "tilePageSize": 9,
         "timeFormat": "YYYY-MMM-DD HH:mm:ss zz",
         "timeZone": "America/New_York",
-        "title": "Message Center"
+        "title": "Message Center",
+        "sortField": "Modified"
       }
     }
   ]

--- a/spfx/src/webparts/messageCenter/MessageCenterWebPart.ts
+++ b/spfx/src/webparts/messageCenter/MessageCenterWebPart.ts
@@ -19,6 +19,7 @@ export interface IMessageCenterWebPartProps {
   timeZone: string;
   title: string;
   webUrl: string;
+  sortField: string
 }
 
 // Reference the solution
@@ -151,6 +152,15 @@ export default class MessageCenterWebPart extends BaseClientSideWebPart<IMessage
                   label: strings.TitleFieldLabel,
                   description: strings.TitleFieldDescription
                 }),
+                PropertyPaneDropdown('sortField', {
+                  label: strings.SortFieldLabel,
+                  selectedKey: 'MessageId', //for the existing deployments out there
+                  options: [
+                    { key: 'MessageId', text: 'Message Id' },
+                    { key: 'Created', text: 'Created Date' },
+                    { key: 'Modified', text: 'Modified Date' }
+                  ]
+                })
               ]
             }
           ]

--- a/spfx/src/webparts/messageCenter/MessageCenterWebPart.ts
+++ b/spfx/src/webparts/messageCenter/MessageCenterWebPart.ts
@@ -41,6 +41,7 @@ declare const MessageCenter: {
     timeFormat?: string;
     timeZone?: string;
     title?: string;
+    sortField?: string;
     sourceUrl?: string;
   }) => void;
   moreInfoTooltip: string;
@@ -49,6 +50,7 @@ declare const MessageCenter: {
   timeFormat: string;
   timeZone: string;
   title: string;
+  sortField: string;
   updateTheme: (currentTheme: Partial<IReadonlyTheme>) => void;
 };
 
@@ -71,6 +73,7 @@ export default class MessageCenterWebPart extends BaseClientSideWebPart<IMessage
     if (!this.properties.timeFormat) { this.properties.timeFormat = MessageCenter.timeFormat; }
     if (!this.properties.timeZone) { this.properties.timeZone = MessageCenter.timeZone; }
     if (!this.properties.title) { this.properties.title = MessageCenter.title; }
+    if (!this.properties.sortField) { this.properties.title = MessageCenter.sortField; }
     if (!this.properties.webUrl) { this.properties.webUrl = this.context.pageContext.web.serverRelativeUrl; }
 
     // Render the application
@@ -87,6 +90,7 @@ export default class MessageCenterWebPart extends BaseClientSideWebPart<IMessage
       timeFormat: this.properties.timeFormat,
       timeZone: this.properties.timeZone,
       title: this.properties.title,
+      sortField: this.properties.sortField,
       sourceUrl: this.properties.webUrl
     });
 

--- a/spfx/src/webparts/messageCenter/MessageCenterWebPart.ts
+++ b/spfx/src/webparts/messageCenter/MessageCenterWebPart.ts
@@ -13,13 +13,13 @@ export interface IMessageCenterWebPartProps {
   listName: string;
   moreInfo: string;
   moreInfoTooltip: string;
+  sortField: string
   tileColumnSize: number;
   tilePageSize: number;
   timeFormat: string;
   timeZone: string;
   title: string;
   webUrl: string;
-  sortField: string
 }
 
 // Reference the solution
@@ -36,21 +36,21 @@ declare const MessageCenter: {
     listName?: string;
     moreInfo?: string;
     moreInfoTooltip?: string;
+    sortField?: string;
+    sourceUrl?: string;
     tileColumnSize?: number;
     tilePageSize?: number;
     timeFormat?: string;
     timeZone?: string;
     title?: string;
-    sortField?: string;
-    sourceUrl?: string;
   }) => void;
   moreInfoTooltip: string;
+  sortField: string;
   tileColumnSize: number;
   tilePageSize: number;
   timeFormat: string;
   timeZone: string;
   title: string;
-  sortField: string;
   updateTheme: (currentTheme: Partial<IReadonlyTheme>) => void;
 };
 
@@ -68,12 +68,12 @@ export default class MessageCenterWebPart extends BaseClientSideWebPart<IMessage
     // Set the default property values
     if (!this.properties.listName) { this.properties.listName = MessageCenter.listName; }
     if (!this.properties.moreInfoTooltip) { this.properties.moreInfoTooltip = MessageCenter.moreInfoTooltip; }
+    if (!this.properties.sortField) { this.properties.sortField = MessageCenter.sortField; }
     if (!this.properties.tileColumnSize) { this.properties.tileColumnSize = MessageCenter.tileColumnSize; }
     if (!this.properties.tilePageSize) { this.properties.tilePageSize = MessageCenter.tilePageSize; }
     if (!this.properties.timeFormat) { this.properties.timeFormat = MessageCenter.timeFormat; }
     if (!this.properties.timeZone) { this.properties.timeZone = MessageCenter.timeZone; }
     if (!this.properties.title) { this.properties.title = MessageCenter.title; }
-    if (!this.properties.sortField) { this.properties.title = MessageCenter.sortField; }
     if (!this.properties.webUrl) { this.properties.webUrl = this.context.pageContext.web.serverRelativeUrl; }
 
     // Render the application
@@ -85,13 +85,13 @@ export default class MessageCenterWebPart extends BaseClientSideWebPart<IMessage
       listName: this.properties.listName,
       moreInfo: this.properties.moreInfo,
       moreInfoTooltip: this.properties.moreInfoTooltip,
+      sortField: this.properties.sortField,
+      sourceUrl: this.properties.webUrl,
       tileColumnSize: this.properties.tileColumnSize,
       tilePageSize: this.properties.tilePageSize,
       timeFormat: this.properties.timeFormat,
       timeZone: this.properties.timeZone,
-      title: this.properties.title,
-      sortField: this.properties.sortField,
-      sourceUrl: this.properties.webUrl
+      title: this.properties.title
     });
 
     // Set the flag

--- a/spfx/src/webparts/messageCenter/loc/en-us.js
+++ b/spfx/src/webparts/messageCenter/loc/en-us.js
@@ -13,6 +13,8 @@ define([], function() {
     "TimeZoneFieldLabel": "Time zone format",
     "TitleFieldDescription": "The text shown in the top-left of the webpart",
     "TitleFieldLabel": "App Title",
+    //"SortFieldDescription": "Sort items in descending order by this field",
+    "SortFieldLabel": "Sort Field",
     "WebUrlFieldDescription": "The relative web URL that contains the Service Health list",
     "WebUrlFieldLabel": "Web Url",
     "AppLocalEnvironmentSharePoint": "The app is running on your local environment as SharePoint web part",

--- a/spfx/src/webparts/messageCenter/loc/mystrings.d.ts
+++ b/spfx/src/webparts/messageCenter/loc/mystrings.d.ts
@@ -12,6 +12,8 @@ declare interface IMessageCenterWebPartStrings {
   TimeZoneFieldLabel: string;
   TitleFieldDescription: string;
   TitleFieldLabel: string;
+  //SortFieldDescription: string;
+  SortFieldLabel: string;
   WebUrlFieldDescription: string;
   WebUrlFieldLabel: string;
   AppLocalEnvironmentSharePoint: string;

--- a/src/cfg.ts
+++ b/src/cfg.ts
@@ -110,7 +110,12 @@ export const Configuration = Helper.SPConfig({
                     fillInChoice: true,
                     multi: true,
                     choices: []
-                } as Helper.IFieldInfoChoice
+                } as Helper.IFieldInfoChoice,
+                {
+                    name: "ItemEnd",
+                    title: "ItemEnd",
+                    type: Helper.SPCfgFieldType.Date
+                }
             ],
             ViewInformation: [
                 {

--- a/src/cfg.ts
+++ b/src/cfg.ts
@@ -39,6 +39,11 @@ export const Configuration = Helper.SPConfig({
                     defaultValue: "0"
                 },
                 {
+                    name: "ItemEnd",
+                    title: "ItemEnd",
+                    type: Helper.SPCfgFieldType.Date
+                },
+                {
                     name: "Message",
                     title: "Message",
                     type: Helper.SPCfgFieldType.Note,
@@ -110,12 +115,7 @@ export const Configuration = Helper.SPConfig({
                     fillInChoice: true,
                     multi: true,
                     choices: []
-                } as Helper.IFieldInfoChoice,
-                {
-                    name: "ItemEnd",
-                    title: "ItemEnd",
-                    type: Helper.SPCfgFieldType.Date
-                }
+                } as Helper.IFieldInfoChoice
             ],
             ViewInformation: [
                 {

--- a/src/ds.ts
+++ b/src/ds.ts
@@ -112,7 +112,7 @@ export class DataSource {
                 webUrl: Strings.SourceUrl,
                 itemQuery: {
                     GetAllItems: true,
-                    OrderBy: ["MessageId desc"],
+                    OrderBy: [Strings.SortField + " desc"],
                     Top: 5000
                 },
                 onInitError: reject,

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -15,6 +15,7 @@ export interface IAppProps {
     timeZone?: string;
     title?: string;
     sourceUrl?: string;
+    sortField?: string;
 }
 
 // Sets the context information
@@ -47,6 +48,9 @@ export const setContext = (props: IAppProps) => {
 
     // Update the ProjectName from SPFx title field
     props.title ? Strings.ProjectName = props.title : null;
+
+    // Update the SortField from SPFx title field
+    props.sortField ? Strings.SortField = props.sortField : null;
 }
 
 /**
@@ -68,6 +72,7 @@ const Strings = {
     TilePageSize: 9,
     TimeFormat: "YYYY-MMM-DD HH:mm:ss zz",
     TimeZone: "America/New_York",
-    Version: "0.0.1"
+    SortField: "Modified",
+    Version: "0.0.3"
 };
 export default Strings;

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -9,13 +9,13 @@ export interface IAppProps {
     listName?: string;
     moreInfo?: string;
     moreInfoTooltip?: string;
+    sortField?: string;
+    sourceUrl?: string;
     tileColumnSize?: number;
     tilePageSize?: number;
     timeFormat?: string;
     timeZone?: string;
     title?: string;
-    sourceUrl?: string;
-    sortField?: string;
 }
 
 // Sets the context information
@@ -67,12 +67,12 @@ const Strings = {
     MoreInfoTooltip: "Click to view additional details for this item.",
     ProjectName: "Message Center",
     ProjectDescription: "The Message Center app is a solution that reads service messages data from a SharePoint list and presents it to all users with an intuitive interface.",
+    SortField: "Modified",
     SourceUrl: ContextInfo.webServerRelativeUrl,
     TileColumnSize: 3,
     TilePageSize: 9,
     TimeFormat: "YYYY-MMM-DD HH:mm:ss zz",
     TimeZone: "America/New_York",
-    SortField: "Modified",
     Version: "0.0.3"
 };
 export default Strings;


### PR DESCRIPTION
The Sort property is used in the SPFx prop pane to control how MC items are returned in the REST call. The prior _fixed_ value of sorting by MessageId was not showing newest MC items in the web part (without needing to page). Now this sort behavior is configurable.

The ItemEnd field is added to be used by the backend flows.
1. Setting the field initially when MC items are created and set to the _end_ date
2. Used by the deletion flow to ensure only the MC items that are actually "over" are deleted